### PR TITLE
TEST-322 OpenId UseCookiesTest fix 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,12 +204,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
-            <version>2.30</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>rhino</groupId>
             <artifactId>js</artifactId>
             <version>1.7R2</version>
@@ -226,6 +220,42 @@
             <artifactId>awaitility</artifactId>
             <version>1.7.0</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <version>2.35.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.8</version>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>7.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.omnifaces</groupId>
+            <artifactId>omniutils</artifactId>
+            <version>0.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.61</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>1.61</version>
         </dependency>
     </dependencies>
 

--- a/samples/openid/pom.xml
+++ b/samples/openid/pom.xml
@@ -2,7 +2,7 @@
 <!--
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
- Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
 
  The contents of this file are subject to the terms of either the GNU
  General Public License Version 2 only ("GPL") or the Common Development
@@ -50,4 +50,13 @@
     <name>Payara Samples - Payara - OpenId Connect</name>
     <packaging>war</packaging>
     
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/samples/openid/src/test/java/fish/payara/security/oidc/test/UseCookiesTest.java
+++ b/samples/openid/src/test/java/fish/payara/security/oidc/test/UseCookiesTest.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -41,8 +41,14 @@ package fish.payara.security.oidc.test;
 
 import com.gargoylesoftware.htmlunit.WebClient;
 import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_USE_SESSION;
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
+import java.security.KeyPair;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -53,6 +59,18 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import static org.omnifaces.utils.security.Certificates.createTempJKSKeyStore;
+import fish.payara.samples.ServerOperations;
+import static org.omnifaces.utils.Lang.isEmpty;
+import static org.omnifaces.utils.security.Certificates.createTempJKSKeyStore;
+import static org.omnifaces.utils.security.Certificates.createTempJKSTrustStore;
+import static org.omnifaces.utils.security.Certificates.generateRandomRSAKeys;
+import static org.omnifaces.utils.security.Certificates.getCertificateChainFromServer;
+import static fish.payara.samples.ServerOperations.addCertificateToContainerTrustStore;
+import static fish.payara.samples.ServerOperations.addContainerSystemProperty;
+import static fish.payara.samples.ServerOperations.createSelfSignedCertificate;
+import static fish.payara.samples.ServerOperations.enableSSLDebug;
+import static fish.payara.samples.ServerOperations.getHostFromCertificate;
 
 /**
  *
@@ -67,10 +85,9 @@ public class UseCookiesTest {
     @ArquillianResource
     private URL base;
 
-    @Before
-    public void init() {
-        webClient = new WebClient();
-    }
+    private URL baseHttps;
+
+    private static String clientKeyStorePath;
 
     @Deployment(name = "openid-server")
     public static WebArchive createServerDeployment() {
@@ -79,16 +96,97 @@ public class UseCookiesTest {
 
     @Deployment(name = "openid-client")
     public static WebArchive createClientDeployment() {
+        System.out.println("\n*********** DEPLOYMENT START ***************************");
+
+        Security.addProvider(new BouncyCastleProvider());
+
+        // Enable to get detailed logging about the SSL handshake on the client
+        // For an explanation of the TLS handshake see: https://tls.ulfheim.net
+        if (System.getProperty("ssl.debug") != null) {
+            enableSSLDebug();
+        }
+
+        System.out.println("################################################################");
+
+        // ### Generate keys for the client, create a certificate, and add those to a new local key store
+        // Generate a Private/Public key pair for the client
+        KeyPair clientKeyPair = generateRandomRSAKeys();
+
+        // Create a certificate containing the client public key and signed with the private key
+        X509Certificate clientCertificate = createSelfSignedCertificate(clientKeyPair);
+
+        // Create a new local key store containing the client private key and the certificate
+        clientKeyStorePath = createTempJKSKeyStore(clientKeyPair.getPrivate(), clientCertificate);
+
+        // Enable to get detailed logging about the SSL handshake on the server
+        if (System.getProperty("ssl.debug") != null) {
+            System.out.println("Setting server SSL debug on");
+            addContainerSystemProperty("javax.net.debug", "ssl:handshake");
+        }
+
+        // Only test TLS v1.2 for now
+        System.setProperty("jdk.tls.client.protocols", "TLSv1.2");
+
+        // Add the client certificate that we just generated to the trust store of the server.
+        // That way the server will trust our certificate.
+        // Set the actual domain used with -Dpayara_domain=[domain name]
+        addCertificateToContainerTrustStore(clientCertificate);
+
         StringAsset mpConfig = new StringAsset(OPENID_MP_USE_SESSION + "=" + Boolean.FALSE.toString());
         return OpenIdTestUtil
                 .createClientDeployment()
                 .addAsWebInfResource(mpConfig, "classes/META-INF/microprofile-config.properties");
     }
 
+    @Before
+    public void setup() throws FileNotFoundException, IOException {
+        webClient = new WebClient();
+        baseHttps = ServerOperations.toContainerHttps(base);
+        if (baseHttps == null) {
+            throw new IllegalStateException("No https URL could be created from " + base);
+        }
+
+        // ### Ask the server for its certificate and add that to a new local trust store
+        // Server -> client : the trust store certificates are used to validate the certificate sent
+        // by the server
+        X509Certificate[] serverCertificateChain = getCertificateChainFromServer(baseHttps.getHost(), baseHttps.getPort());
+
+        if (!isEmpty(serverCertificateChain)) {
+
+            System.out.println("Obtained certificate from server. Storing it in client trust store");
+
+            String trustStorePath = createTempJKSTrustStore(serverCertificateChain);
+
+            System.out.println("Reading trust store from: " + trustStorePath);
+
+            webClient.getOptions().setSSLTrustStore(new File(trustStorePath).toURI().toURL(), "changeit", "jks");
+
+            // If the use.cnHost property is we try to extract the host from the server
+            // certificate and use exactly that host for our requests.
+            // This is needed if a server is listening to multiple host names, for instance
+            // localhost and example.com. If the certificate is for example.com, we can't
+            // localhost for the request, as that will not be accepted.
+            if (System.getProperty("use.cnHost") != null) {
+                System.out.println("use.cnHost set. Trying to grab CN from certificate and use as host for requests.");
+                baseHttps = getHostFromCertificate(serverCertificateChain, baseHttps);
+            }
+        } else {
+            System.out.println("Could not obtain certificates from server. Continuing without custom truststore");
+        }
+
+        System.out.println("Using client key store from: " + clientKeyStorePath);
+
+        // Client -> Server : the key store's private keys and certificates are used to sign
+        // and sent a reply to the server
+        webClient.getOptions().setSSLClientCertificate(new File(clientKeyStorePath).toURI().toURL(), "changeit", "jks");
+
+        System.out.println("*********** SETUP DONE ***************************\n");
+    }
+
     @Test
     @RunAsClient
     public void testOpenIdConnect() throws IOException {
-        OpenIdTestUtil.testOpenIdConnect(webClient, base);
+        OpenIdTestUtil.testOpenIdConnect(webClient, baseHttps);
     }
 
 }

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -26,11 +26,6 @@
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-api-maven</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.nimbusds</groupId>
-            <artifactId>nimbus-jose-jwt</artifactId>
-            <version>5.1</version>
-        </dependency>
     </dependencies>
     
 </project>


### PR DESCRIPTION
If `payara.security.openid.useSession` property set to `false`, Cookies are used for storage of OpenId state and nonce with attribute HttpOnly & Secure. So to fix the testcase base url changed to Https base url.