### PR TITLE
PAYARA-3729 Adds simple test application to verify EJB over HTTP client-endpoint communication

### DIFF
--- a/samples/ejb/http-client-test-app/README.md
+++ b/samples/ejb/http-client-test-app/README.md
@@ -1,0 +1,7 @@
+# EJB over HTTP Client Test Application
+
+## Usage
+1. Create a `test.jar` file containing the classes of `model` and `server` package (e.g. simple _jar_ export).
+2. Deploy the created `test.jar` in the application server using the admin console. The application should be named `test`.
+3. Run the `Client` as normal Java application. You should get value output.
+  If exceptions are printed the communication is broken.

--- a/samples/ejb/http-client-test-app/pom.xml
+++ b/samples/ejb/http-client-test-app/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>fish.payara.test</groupId>
+    <artifactId>http-client-test-app</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>http-client-test-app</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>payara-patched-externals</id>
+            <name>Payara Patched Externals</name>
+            <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
+            <!--<url>file:///opt/PayaraDev/Payara_PatchedProjects</url> -->
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.ejb.http</groupId>
+            <artifactId>ejb-http-client</artifactId>
+            <version>5.192-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.ejb</groupId>
+            <artifactId>javax.ejb-api</artifactId>
+            <version>3.2.2</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/samples/ejb/http-client-test-app/src/main/java/fish/payara/test/ejb/httpclient/client/Client.java
+++ b/samples/ejb/http-client-test-app/src/main/java/fish/payara/test/ejb/httpclient/client/Client.java
@@ -1,0 +1,58 @@
+package fish.payara.test.ejb.httpclient.client;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+import fish.payara.test.ejb.httpclient.server.Bean;
+import fish.payara.test.ejb.httpclient.server.BeanRemote;
+import fish.payara.test.ejb.httpclient.server.EmployeeBean;
+import fish.payara.test.ejb.httpclient.server.EmployeeServiceRemote;
+
+/**
+ * Client application to verify EJB over HTTP implementation.
+ * 
+ * To package the server create a jar with the model and server package in it and deploy the application named "test".
+ */
+public class Client {
+
+    public static void main(String[] args) throws Exception {
+        Hashtable<String, String> environment = new Hashtable<>();
+        environment.put(Context.INITIAL_CONTEXT_FACTORY, "fish.payara.ejb.rest.client.RemoteEJBContextFactory");
+        environment.put(Context.PROVIDER_URL, "http://localhost:8080/ejb-invoker");
+
+        Context context = new InitialContext(environment);
+        ejbByClassAndInterfaceName(context);
+        ejbByClassName(context);
+        ejbByInterfaceName(context);
+    }
+
+    private static void ejbByInterfaceName(Context context) {
+        try {
+            BeanRemote bean = (BeanRemote) context.lookup(BeanRemote.class.getName());
+            System.out.println(bean.method());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    private static void ejbByClassName(Context context) {
+        try {
+            BeanRemote bean = (BeanRemote) context.lookup("java:global/test/" + Bean.class.getSimpleName());
+            System.out.println(bean.method());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    private static void ejbByClassAndInterfaceName(Context context) {
+        try {
+            EmployeeServiceRemote bean = (EmployeeServiceRemote) context.lookup("java:global/test/"
+                    + EmployeeBean.class.getSimpleName() + "!" + EmployeeServiceRemote.class.getName());
+            System.out.println(bean.doAction());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+}

--- a/samples/ejb/http-client-test-app/src/main/java/fish/payara/test/ejb/httpclient/model/CustomValue.java
+++ b/samples/ejb/http-client-test-app/src/main/java/fish/payara/test/ejb/httpclient/model/CustomValue.java
@@ -1,0 +1,24 @@
+package fish.payara.test.ejb.httpclient.model;
+
+import java.io.Serializable;
+
+import javax.json.bind.annotation.JsonbProperty;
+
+public class CustomValue implements Serializable {
+
+    @JsonbProperty
+    private Integer value;
+
+    public Integer getValue() {
+        return value;
+    }
+
+    public void setValue(Integer value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value == null ? "" : value.toString();
+    }
+}

--- a/samples/ejb/http-client-test-app/src/main/java/fish/payara/test/ejb/httpclient/server/Bean.java
+++ b/samples/ejb/http-client-test-app/src/main/java/fish/payara/test/ejb/httpclient/server/Bean.java
@@ -1,0 +1,22 @@
+package fish.payara.test.ejb.httpclient.server;
+
+import java.io.Serializable;
+
+import javax.ejb.Stateless;
+
+import fish.payara.test.ejb.httpclient.model.CustomValue;
+
+@Stateless
+public class Bean implements BeanRemote, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public CustomValue method() {
+        CustomValue res = new CustomValue();
+        res.setValue(5);
+        return res;
+    }
+
+}
+

--- a/samples/ejb/http-client-test-app/src/main/java/fish/payara/test/ejb/httpclient/server/BeanRemote.java
+++ b/samples/ejb/http-client-test-app/src/main/java/fish/payara/test/ejb/httpclient/server/BeanRemote.java
@@ -1,0 +1,10 @@
+package fish.payara.test.ejb.httpclient.server;
+
+import javax.ejb.Remote;
+
+import fish.payara.test.ejb.httpclient.model.CustomValue;
+
+@Remote
+public interface BeanRemote {
+    CustomValue method();
+}

--- a/samples/ejb/http-client-test-app/src/main/java/fish/payara/test/ejb/httpclient/server/EmployeeBean.java
+++ b/samples/ejb/http-client-test-app/src/main/java/fish/payara/test/ejb/httpclient/server/EmployeeBean.java
@@ -1,0 +1,17 @@
+package fish.payara.test.ejb.httpclient.server;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class EmployeeBean implements EmployeeServiceLocal, EmployeeServiceRemote {
+
+    @Override
+    public Map<String, String> doAction() {
+        HashMap<String, String> map = new HashMap<>();
+        map.put("foo", "bar");
+        return map;
+    }
+    
+}

--- a/samples/ejb/http-client-test-app/src/main/java/fish/payara/test/ejb/httpclient/server/EmployeeServiceLocal.java
+++ b/samples/ejb/http-client-test-app/src/main/java/fish/payara/test/ejb/httpclient/server/EmployeeServiceLocal.java
@@ -1,0 +1,13 @@
+package fish.payara.test.ejb.httpclient.server;
+
+
+import java.util.Map;
+
+import javax.ejb.Local;
+
+@Local
+public interface EmployeeServiceLocal {
+    Map<String, String> doAction();
+
+
+}

--- a/samples/ejb/http-client-test-app/src/main/java/fish/payara/test/ejb/httpclient/server/EmployeeServiceRemote.java
+++ b/samples/ejb/http-client-test-app/src/main/java/fish/payara/test/ejb/httpclient/server/EmployeeServiceRemote.java
@@ -1,0 +1,10 @@
+package fish.payara.test.ejb.httpclient.server;
+import java.util.Map;
+
+import javax.ejb.Remote;
+
+
+@Remote
+public interface EmployeeServiceRemote {
+  Map<String, String> doAction();
+}


### PR DESCRIPTION
Mind you that I created this just to test the feature not to make a nice example. 

As the purpose is especially to verify that a client works with the minimum of dependencies this module should absolutely **not** have any parent.