### PR TITLE
PAYARA-3521: Test case for using Jersey outside of running embedded server

### DIFF
--- a/classpath/embedded-vs-jersey/pom.xml
+++ b/classpath/embedded-vs-jersey/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  ~
+  ~    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~    The contents of this file are subject to the terms of either the GNU
+  ~    General Public License Version 2 only ("GPL") or the Common Development
+  ~    and Distribution License("CDDL") (collectively, the "License").  You
+  ~    may not use this file except in compliance with the License.  You can
+  ~    obtain a copy of the License at
+  ~    https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~    See the License for the specific
+  ~    language governing permissions and limitations under the License.
+  ~
+  ~    When distributing the software, include this License Header Notice in each
+  ~    file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~    GPL Classpath Exception:
+  ~    The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~    file that accompanied this code.
+  ~
+  ~    Modifications:
+  ~    If applicable, add the following below the License Header, with the fields
+  ~    enclosed by brackets [] replaced by your own identifying information:
+  ~    "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~    Contributor(s):
+  ~    If you wish your version of this file to be governed by only the CDDL or
+  ~    only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~    elects to include this software in this distribution under the [CDDL or GPL
+  ~    Version 2] license."  If you don't indicate a single choice of license, a
+  ~    recipient has the option to distribute your version of this file under
+  ~    either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~    its licensees as provided above.  However, if you add GPL Version 2 code
+  ~    and therefore, elected the GPL Version 2 license, then the option applies
+  ~    only if the new code is made subject to such option by the copyright
+  ~    holder.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>classpath</artifactId>
+        <groupId>fish.payara.samples</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>embedded-vs-jersey</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.extras</groupId>
+            <artifactId>payara-embedded-all</artifactId>
+            <version>${payara.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/classpath/embedded-vs-jersey/src/test/java/fish/payara/samples/classpath/embeddedvsjersey/JerseyClasspathTest.java
+++ b/classpath/embedded-vs-jersey/src/test/java/fish/payara/samples/classpath/embeddedvsjersey/JerseyClasspathTest.java
@@ -1,0 +1,55 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.samples.classpath.embeddedvsjersey;
+
+import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+
+public class JerseyClasspathTest {
+
+    @Test
+    public void jerseyShouldInitialize() {
+        Client client = ClientBuilder.newClient();
+        client.target("http://localhost:8080").request().buildGet();
+    }
+}

--- a/classpath/pom.xml
+++ b/classpath/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>fish.payara.samples</groupId>
+  <artifactId>classpath</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Classpath tests</name>
+  <description>These test verify that artifacts provide classpath isolated enough not to interfere with client code
+  in unexpected ways.</description>
+
+  <properties>
+    <payara.version>5.192-SNAPSHOT</payara.version>
+  </properties>
+
+  <modules>
+    <module>embedded-vs-jersey</module>
+  </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
     <modules>
         <module>samples</module>
         <module>test-utils</module>
+        <module>classpath</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
Added new module, which does not inherit any dependencies, as classloading-related tests need those under control