### PR TITLE
[TEST-328] Payara Samples fails to clean up after self

### DIFF
--- a/samples/asadmin/src/test/java/fish/payara/samples/asadmin/RegisterLoginModuleTest.java
+++ b/samples/asadmin/src/test/java/fish/payara/samples/asadmin/RegisterLoginModuleTest.java
@@ -62,6 +62,10 @@ public class RegisterLoginModuleTest extends AsadminTest {
         assertSuccess(result);
         String contents = loginConf();
         assertContains("test1 {", contents);
+        
+        result = asadmin("delete-auth-realm", "test1");
+        System.out.println(result.getOutput());
+        assertSuccess(result);
     }
 
     @Test
@@ -73,6 +77,10 @@ public class RegisterLoginModuleTest extends AsadminTest {
         System.out.println(result.getOutput());
         assertEquals(CommandResult.ExitStatus.WARNING, result.getExitStatus());
         assertContains("fileRealm is already configured", result.getOutput());
+        
+        result = asadmin("delete-auth-realm", "test2");
+        System.out.println(result.getOutput());
+        assertSuccess(result);
     }
 
     @Test
@@ -84,6 +92,10 @@ public class RegisterLoginModuleTest extends AsadminTest {
         System.out.println(result.getOutput());
         assertEquals(CommandResult.ExitStatus.WARNING, result.getExitStatus());
         assertContains("No JAAS context is defined", result.getOutput());
+        
+        result = asadmin("delete-auth-realm", "test3");
+        System.out.println(result.getOutput());
+        assertSuccess(result);
     }
 
     private String loginConf() throws IOException {

--- a/samples/asadmin/src/test/java/fish/payara/samples/asadmin/RegisterLoginModuleTest.java
+++ b/samples/asadmin/src/test/java/fish/payara/samples/asadmin/RegisterLoginModuleTest.java
@@ -116,25 +116,6 @@ public class RegisterLoginModuleTest extends AsadminTest {
         System.out.println(result.getOutput());
         assertSuccess(result);
     }
-    
-//    @After
-//    public void cleanupJAASContext() throws IOException {
-//    
-//        String originalFileContents = loginConf();
-//        
-//        if(originalFileContents.contains("test1 {")) {
-//            String newFileContents = originalFileContents.replaceFirst("test1 { .* };", "");
-//            try {
-//                BufferedWriter writer = new BufferedWriter(new FileWriter(System.getProperty("java.security.auth.login.config")));
-//                writer.write(newFileContents);
-//                writer.close();
-//            } catch(IOException e) {
-//                System.out.print(e.getMessage());
-//                e.printStackTrace();
-//            }
-//        }
-//        
-//    }
 
     private String loginConf() throws IOException {
         File loginConf = new File(System.getProperty("java.security.auth.login.config"));

--- a/samples/asadmin/src/test/java/fish/payara/samples/asadmin/RegisterLoginModuleTest.java
+++ b/samples/asadmin/src/test/java/fish/payara/samples/asadmin/RegisterLoginModuleTest.java
@@ -71,7 +71,11 @@ public class RegisterLoginModuleTest extends AsadminTest {
         System.out.println(result.getOutput());
         assertSuccess(result);
        
-        String newFileContents = contents.replace(contents.substring(contents.indexOf("test1")), "");
+        //Removes JAAS context test1 from the login.conf file on the domain
+        //It's expected that this will be the last entry in the login.conf file
+        //and so we just grab everything up to this final entry as the new file
+        //contents
+        String newFileContents = contents.substring(0, contents.indexOf("test1"));
         System.out.print(newFileContents);
         try(BufferedWriter writer = new BufferedWriter(new FileWriter(System.getProperty("java.security.auth.login.config")))) {        
             writer.write(newFileContents);

--- a/samples/asadmin/src/test/java/fish/payara/samples/asadmin/RegisterLoginModuleTest.java
+++ b/samples/asadmin/src/test/java/fish/payara/samples/asadmin/RegisterLoginModuleTest.java
@@ -73,10 +73,8 @@ public class RegisterLoginModuleTest extends AsadminTest {
        
         String newFileContents = contents.replace(contents.substring(contents.indexOf("test1")), "");
         System.out.print(newFileContents);
-        try {
-            BufferedWriter writer = new BufferedWriter(new FileWriter(System.getProperty("java.security.auth.login.config")));
+        try(BufferedWriter writer = new BufferedWriter(new FileWriter(System.getProperty("java.security.auth.login.config")))) {        
             writer.write(newFileContents);
-            writer.close();
         } catch(IOException e) {
             System.out.print(e.getMessage());
             e.printStackTrace();

--- a/samples/asadmin/src/test/java/fish/payara/samples/asadmin/RegisterLoginModuleTest.java
+++ b/samples/asadmin/src/test/java/fish/payara/samples/asadmin/RegisterLoginModuleTest.java
@@ -70,19 +70,17 @@ public class RegisterLoginModuleTest extends AsadminTest {
         result = asadmin("delete-auth-realm", "test1");
         System.out.println(result.getOutput());
         assertSuccess(result);
-        
-        if (contents.contains("test1 {")) {
-            String newFileContents = contents.replace(contents.substring(contents.indexOf("test1")), "");
-            System.out.print(newFileContents);
-            try {
-                BufferedWriter writer = new BufferedWriter(new FileWriter(System.getProperty("java.security.auth.login.config")));
-                writer.write(newFileContents);
-                writer.close();
-            } catch(IOException e) {
-                System.out.print(e.getMessage());
-                e.printStackTrace();
-            }
-        }
+       
+        String newFileContents = contents.replace(contents.substring(contents.indexOf("test1")), "");
+        System.out.print(newFileContents);
+        try {
+            BufferedWriter writer = new BufferedWriter(new FileWriter(System.getProperty("java.security.auth.login.config")));
+            writer.write(newFileContents);
+            writer.close();
+        } catch(IOException e) {
+            System.out.print(e.getMessage());
+            e.printStackTrace();
+        }     
         
         assertFalse(loginConf().contains("test1 {"));
     }

--- a/samples/asadmin/src/test/java/fish/payara/samples/asadmin/RegisterLoginModuleTest.java
+++ b/samples/asadmin/src/test/java/fish/payara/samples/asadmin/RegisterLoginModuleTest.java
@@ -41,13 +41,17 @@
 package fish.payara.samples.asadmin;
 
 import com.google.common.io.CharStreams;
+import java.io.BufferedWriter;
 import org.glassfish.embeddable.CommandResult;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
+import java.util.regex.Pattern;
+import org.junit.After;
 import static org.junit.Assert.assertEquals;
 
 public class RegisterLoginModuleTest extends AsadminTest {
@@ -66,6 +70,21 @@ public class RegisterLoginModuleTest extends AsadminTest {
         result = asadmin("delete-auth-realm", "test1");
         System.out.println(result.getOutput());
         assertSuccess(result);
+        
+        if (contents.contains("test1 {")) {
+            String newFileContents = contents.replace(contents.substring(contents.indexOf("test1")), "");
+            System.out.print(newFileContents);
+            try {
+                BufferedWriter writer = new BufferedWriter(new FileWriter(System.getProperty("java.security.auth.login.config")));
+                writer.write(newFileContents);
+                writer.close();
+            } catch(IOException e) {
+                System.out.print(e.getMessage());
+                e.printStackTrace();
+            }
+        }
+        
+        assertFalse(loginConf().contains("test1 {"));
     }
 
     @Test
@@ -97,6 +116,25 @@ public class RegisterLoginModuleTest extends AsadminTest {
         System.out.println(result.getOutput());
         assertSuccess(result);
     }
+    
+//    @After
+//    public void cleanupJAASContext() throws IOException {
+//    
+//        String originalFileContents = loginConf();
+//        
+//        if(originalFileContents.contains("test1 {")) {
+//            String newFileContents = originalFileContents.replaceFirst("test1 { .* };", "");
+//            try {
+//                BufferedWriter writer = new BufferedWriter(new FileWriter(System.getProperty("java.security.auth.login.config")));
+//                writer.write(newFileContents);
+//                writer.close();
+//            } catch(IOException e) {
+//                System.out.print(e.getMessage());
+//                e.printStackTrace();
+//            }
+//        }
+//        
+//    }
 
     private String loginConf() throws IOException {
         File loginConf = new File(System.getProperty("java.security.auth.login.config"));


### PR DESCRIPTION
Issue arises due to JAAS context created in initial run of test suite persisting across runs. This means that the first test case of RegisterLoginModuleTest will always fail after an initial run of the test suite. The change I've made does resolve this issue but does require a manual server restart after running as, for some reason, having this restart done in the code breaks the following tests.