### PR TITLE
[TEST-336] - CustomLoginModuleTest was broken

### DIFF
--- a/samples/custom-loginmodule-realm/loginmodule-realm-test/src/test/java/fish/payara/samples/loginmodule/realm/custom/CustomLoginModuleRealmTest.java
+++ b/samples/custom-loginmodule-realm/loginmodule-realm-test/src/test/java/fish/payara/samples/loginmodule/realm/custom/CustomLoginModuleRealmTest.java
@@ -67,9 +67,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 
 import fish.payara.samples.CliCommands;
 import fish.payara.samples.ServerOperations;
-import fish.payara.samples.loginmodule.realm.custom.CustomLoginModule;
-import fish.payara.samples.loginmodule.realm.custom.CustomRealm;
-import fish.payara.samples.loginmodule.realm.custom.TestServlet;
 
 @RunWith(Arquillian.class)
 public class CustomLoginModuleRealmTest {

--- a/samples/custom-loginmodule-realm/loginmodule-realm-test/src/test/java/fish/payara/samples/loginmodule/realm/custom/CustomLoginModuleRealmTest.java
+++ b/samples/custom-loginmodule-realm/loginmodule-realm-test/src/test/java/fish/payara/samples/loginmodule/realm/custom/CustomLoginModuleRealmTest.java
@@ -80,39 +80,38 @@ public class CustomLoginModuleRealmTest {
 
     @Deployment(testable = false)
     public static WebArchive createDeployment() {
-        
+
         addMavenJarsToContainerLibFolder("pom.xml", "fish.payara.samples:loginmodule-realm-impl");
         ServerOperations.restartContainer();
-        
+
         List<String> cmd = new ArrayList<>();
-        
+
         cmd.add("delete-auth-realm");
         cmd.add("custom");
         CliCommands.payaraGlassFish(cmd);
-        
+
         cmd.clear();
 
         cmd.add("create-auth-realm");
-        
+
         cmd.add("--login-module");
         cmd.add(CustomLoginModule.class.getName());
-        
+
         cmd.add("--classname");
         cmd.add(CustomRealm.class.getName());
-        
+
         cmd.add("--property");
         cmd.add("jaas-context=customRealm");
-        
+
         cmd.add("custom");
-        
+
         CliCommands.payaraGlassFish(cmd);
-        
+
         ServerOperations.restartContainer();
-        
+
         return ShrinkWrap.create(WebArchive.class)
                 .addClass(TestServlet.class)
-                .addAsWebInfResource(new File(WEBAPP_SOURCE, "WEB-INF/web.xml"))
-                ;
+                .addAsWebInfResource(new File(WEBAPP_SOURCE, "WEB-INF/web.xml"));
     }
 
     @Before
@@ -123,19 +122,19 @@ public class CustomLoginModuleRealmTest {
     @Test
     @RunAsClient
     public void testAuthenticationWithCorrectUser() throws FailingHttpStatusCodeException, MalformedURLException, IOException {
-        
+
         System.out.println("\n\nRequesting: " + (base + "testServlet"));
-        
+
         DefaultCredentialsProvider credentialsProvider = new DefaultCredentialsProvider();
         credentialsProvider.addCredentials("realmUser", "realmPassword");
-        
+
         webClient.setCredentialsProvider(credentialsProvider);
         TextPage page = webClient.getPage(base + "testServlet");
-        
+
         System.out.println(page.getContent());
-        
+
         assertTrue("my GET", page.getContent().contains("This is a test servlet"));
-        
+
         assertTrue("User doesn't have the corrrect role", page.getContent().contains("web user has role \"realmGroup\": true"));
     }
 


### PR DESCRIPTION
Original issue was raised due to a test failure which appears to have been resolved subsequent to the fixing of another issue or updates in the latest version of the server.
This PR just removes some unnecessary package imports and does some very very minor reformatting (i.e. removal of tabzz).