### PR TITLE
PAYARA-3864 Parameterised EJB tests to test both versions and serialisation types

### DIFF
--- a/samples/ejb-http-remoting/api/src/main/java/fish/payara/samples/ejbhttp/api/Stuff.java
+++ b/samples/ejb-http-remoting/api/src/main/java/fish/payara/samples/ejbhttp/api/Stuff.java
@@ -42,17 +42,19 @@ package fish.payara.samples.ejbhttp.api;
 
 import javax.json.bind.annotation.JsonbTypeDeserializer;
 import javax.json.bind.annotation.JsonbTypeSerializer;
+
+import java.io.Serializable;
 import java.util.function.Supplier;
 
 /**
  * It is impossible to do top level polymorphism with JSON-B.
  * One needs to create container outside of hierarchy that will host the mapping.
  */
-public interface Stuff {
+public interface Stuff extends Serializable {
 
     @JsonbTypeSerializer(TypeKeySerializer.class)
     @JsonbTypeDeserializer(TypeKeyDeserializer.class)
-    class Container implements Supplier<Stuff> {
+    class Container implements Supplier<Stuff>, Serializable {
         private Stuff instance;
 
         public Container(Stuff instance) {

--- a/samples/ejb-http-remoting/api/src/main/java/fish/payara/samples/ejbhttp/api/TypeKeyDeserializer.java
+++ b/samples/ejb-http-remoting/api/src/main/java/fish/payara/samples/ejbhttp/api/TypeKeyDeserializer.java
@@ -48,9 +48,7 @@ import java.lang.reflect.Type;
 public class TypeKeyDeserializer implements JsonbDeserializer<Stuff.Container> {
     @Override
     public Stuff.Container deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
-        if (parser.hasNext()) {
-            // there's more, we're on START_OBJECT
-            parser.next();
+        if (parser.hasNext() && parser.next() == JsonParser.Event.KEY_NAME) {
             String className = parser.getString();
             try {
                 Class<?> valueClass = Class.forName(className);

--- a/samples/ejb-http-remoting/api/src/main/java/fish/payara/samples/ejbhttp/api/User.java
+++ b/samples/ejb-http-remoting/api/src/main/java/fish/payara/samples/ejbhttp/api/User.java
@@ -40,10 +40,11 @@
 
 package fish.payara.samples.ejbhttp.api;
 
+import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.List;
 
-public class User {
+public class User implements Serializable {
     public String login;
     public LocalDate createdAt;
     public List<User> friends;

--- a/samples/ejb-http-remoting/client/REDME.md
+++ b/samples/ejb-http-remoting/client/REDME.md
@@ -1,0 +1,12 @@
+# Running Tests (CI Way)
+
+* start Payara locally
+* enable `ejb-invoker` app using `enable-ejb-invoker` asadmin command
+* run `mvn verify -Ppayara-server-remote`
+
+# Running Tests (Debug)
+
+* start Payara locally
+* enable `ejb-invoker` app using `enable-ejb-invoker` asadmin command
+* build `server-app` module (sibling to this module) and deploy it manually named `server-app`
+* run the tests in IDE (run as JUnit test)

--- a/samples/ejb-http-remoting/client/pom.xml
+++ b/samples/ejb-http-remoting/client/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>fish.payara.ejb.http</groupId>
             <artifactId>ejb-http-client</artifactId>
-            <version>5.192-SNAPSHOT</version>
+            <version>5.193-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/samples/ejb-http-remoting/client/src/main/java/fish/payara/samples/ejbhttp/client/JmsClientExample.java
+++ b/samples/ejb-http-remoting/client/src/main/java/fish/payara/samples/ejbhttp/client/JmsClientExample.java
@@ -58,15 +58,16 @@ import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
 import static javax.naming.Context.PROVIDER_URL;
 
 public enum JmsClientExample {
-    INSTANCE;
+    JSON_V0(0),
+    JSON_V1(1);
 
     private final InitialContext context;
 
-    JmsClientExample() {
+    JmsClientExample(int version) {
         Hashtable<String, Object> environment = new Hashtable<>();
         environment.put(INITIAL_CONTEXT_FACTORY, "fish.payara.ejb.rest.client.RemoteEJBContextFactory");
         environment.put(PROVIDER_URL, "http://localhost:8080/ejb-invoker");
-
+        environment.put(RemoteEJBContextFactory.JAXRS_CLIENT_VERSION, version);
         try {
             // Prepare Client locally
             QueueConnectionFactory jmsConnectionFactory = new QueueConnectionFactory();

--- a/samples/ejb-http-remoting/client/src/test/java/AbstractClientIT.java
+++ b/samples/ejb-http-remoting/client/src/test/java/AbstractClientIT.java
@@ -1,5 +1,44 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
 import java.util.Arrays;
-import java.util.stream.Collectors;
 
 import javax.naming.NamingException;
 
@@ -19,13 +58,12 @@ public abstract class AbstractClientIT {
     protected RemoteService remoteService;
 
     @Parameters(name = "{0}")
-    public static Iterable<String> connectors() {
-        return Arrays.asList(RemoteConnector.values()).stream().map(
-                item -> item.name()).collect(Collectors.toList());
+    public static Iterable<RemoteConnector> connectors() {
+        return Arrays.asList(RemoteConnector.values());
     }
 
     @Parameter
-    public String connectorName;
+    public RemoteConnector connector;
 
     @Before
     public void lookup() throws NamingException {
@@ -33,7 +71,7 @@ public abstract class AbstractClientIT {
     }
 
     protected final RemoteConnector getConnector() {
-        return RemoteConnector.valueOf(connectorName);
+        return connector;
     }
 
     protected final boolean isJavaSerialization() {

--- a/samples/ejb-http-remoting/client/src/test/java/AbstractClientIT.java
+++ b/samples/ejb-http-remoting/client/src/test/java/AbstractClientIT.java
@@ -1,0 +1,50 @@
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import javax.naming.NamingException;
+
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import fish.payara.ejb.http.protocol.SerializationType;
+import fish.payara.samples.ejbhttp.api.RemoteService;
+import fish.payara.samples.ejbhttp.client.RemoteConnector;
+
+@RunWith(Parameterized.class)
+public abstract class AbstractClientIT {
+
+    protected RemoteService remoteService;
+
+    @Parameters(name = "{0}")
+    public static Iterable<String> connectors() {
+        return Arrays.asList(RemoteConnector.values()).stream().map(
+                item -> item.name()).collect(Collectors.toList());
+    }
+
+    @Parameter
+    public String connectorName;
+
+    @Before
+    public void lookup() throws NamingException {
+        remoteService = getConnector().lookup("java:global/server-app/RemoteServiceBean");
+    }
+
+    protected final RemoteConnector getConnector() {
+        return RemoteConnector.valueOf(connectorName);
+    }
+
+    protected final boolean isJavaSerialization() {
+        return getSerializationType() == SerializationType.JAVA;
+    }
+
+    protected final SerializationType getSerializationType() {
+        return getConnector().getSerializationType();
+    }
+
+    protected final int getVersion() {
+        return getConnector().getVersion();
+    }
+}

--- a/samples/ejb-http-remoting/client/src/test/java/CollectionTypesIT.java
+++ b/samples/ejb-http-remoting/client/src/test/java/CollectionTypesIT.java
@@ -38,13 +38,9 @@
  *    holder.
  */
 
-import fish.payara.samples.ejbhttp.api.RemoteService;
 import fish.payara.samples.ejbhttp.api.User;
-import fish.payara.samples.ejbhttp.client.RemoteConnector;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
-import javax.naming.NamingException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -57,13 +53,7 @@ import static org.junit.Assert.assertNull;
 /**
  * Test collections as arguments and return types
  */
-public class CollectionTypesIT {
-    static RemoteService remoteService;
-
-    @BeforeClass
-    public static void lookup() throws NamingException {
-        remoteService = RemoteConnector.INSTANCE.lookup("java:global/server-app/RemoteServiceBean");
-    }
+public class CollectionTypesIT extends AbstractClientIT {
 
     @Test
     public void testElementaryListReturnNull() {

--- a/samples/ejb-http-remoting/client/src/test/java/CustomizedTypesIT.java
+++ b/samples/ejb-http-remoting/client/src/test/java/CustomizedTypesIT.java
@@ -38,33 +38,27 @@
  *    holder.
  */
 
+import fish.payara.ejb.http.protocol.SerializationType;
 import fish.payara.samples.ejbhttp.api.Product;
 import fish.payara.samples.ejbhttp.api.Ranking;
-import fish.payara.samples.ejbhttp.api.RemoteService;
 import fish.payara.samples.ejbhttp.api.Stuff;
-import fish.payara.samples.ejbhttp.client.RemoteConnector;
-import org.junit.BeforeClass;
+import fish.payara.samples.ejbhttp.api.Stuff.Container;
+
 import org.junit.Test;
 
-import javax.naming.NamingException;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 /**
  * Ten customized JSON-B serialization
  */
-public class CustomizedTypesIT {
-    static RemoteService remoteService;
-
-    @BeforeClass
-    public static void lookup() throws NamingException {
-        remoteService = RemoteConnector.INSTANCE.lookup("java:global/server-app/RemoteServiceBean");
-    }
+public class CustomizedTypesIT extends AbstractClientIT {
 
     @Test
     public void annotatedSerializerTopLevelReturn() {
@@ -85,7 +79,12 @@ public class CustomizedTypesIT {
 
     @Test
     public void annotatedSerializerTopLevelReturnNull() {
-        assertThat(remoteService.polymorphicReturn(true).get()).isNull();
+        Container result = remoteService.polymorphicReturn(true);
+        if (getSerializationType() == SerializationType.JSON) {
+            assertThat(result.get()).isNull();
+        } else {
+            assertNull(result);
+        }
     }
 
     @Test

--- a/samples/ejb-http-remoting/client/src/test/java/JmsIT.java
+++ b/samples/ejb-http-remoting/client/src/test/java/JmsIT.java
@@ -52,7 +52,6 @@ import javax.naming.NamingException;
 import javax.rmi.PortableRemoteObject;
 import java.lang.IllegalStateException;
 import java.util.Arrays;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -60,18 +59,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JmsIT {
 
     @Parameters(name = "{0}")
-    public static Iterable<String> clients() {
-        return Arrays.asList(JmsClientExample.values()).stream().map(
-                item -> item.name()).collect(Collectors.toList());
+    public static Iterable<JmsClientExample> clients() {
+        return Arrays.asList(JmsClientExample.values());
     }
 
     @Parameter
-    public String clientName;
+    public JmsClientExample client;
 
     @Test
     public void sendAndReceiveMessage() throws NamingException, JMSException {
         final String connectionFactoryName = "jms/ConnectionFactory";
-        InitialContext jndi = JmsClientExample.valueOf(clientName).getContext();
+        InitialContext jndi = client.getContext();
 
         // some real world JMS over remote JNDI code...
 

--- a/samples/ejb-http-remoting/client/src/test/java/JmsIT.java
+++ b/samples/ejb-http-remoting/client/src/test/java/JmsIT.java
@@ -39,21 +39,39 @@
  */
 
 import fish.payara.samples.ejbhttp.client.JmsClientExample;
+
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 import javax.jms.*;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.rmi.PortableRemoteObject;
 import java.lang.IllegalStateException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(Parameterized.class)
 public class JmsIT {
+
+    @Parameters(name = "{0}")
+    public static Iterable<String> clients() {
+        return Arrays.asList(JmsClientExample.values()).stream().map(
+                item -> item.name()).collect(Collectors.toList());
+    }
+
+    @Parameter
+    public String clientName;
+
     @Test
     public void sendAndReceiveMessage() throws NamingException, JMSException {
         final String connectionFactoryName = "jms/ConnectionFactory";
-        InitialContext jndi = JmsClientExample.INSTANCE.getContext();
+        InitialContext jndi = JmsClientExample.valueOf(clientName).getContext();
 
         // some real world JMS over remote JNDI code...
 

--- a/samples/ejb-http-remoting/client/src/test/java/LookupIT.java
+++ b/samples/ejb-http-remoting/client/src/test/java/LookupIT.java
@@ -41,7 +41,6 @@
 import fish.payara.samples.ejbhttp.api.ExposedService;
 import fish.payara.samples.ejbhttp.api.RemoteService;
 import fish.payara.samples.ejbhttp.api.User;
-import fish.payara.samples.ejbhttp.client.RemoteConnector;
 import org.junit.Test;
 
 import javax.naming.NamingException;
@@ -51,23 +50,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Test using various lookup strings for obtaiing the proxy
  */
-public class LookupIT {
+public class LookupIT extends AbstractClientIT {
     @Test
     public void ejbByInterfaceName() throws NamingException {
-        ExposedService bean = RemoteConnector.INSTANCE.lookup(ExposedService.class.getName());
-        assertThat(bean.createSimpleUser()).isInstanceOf(User.class);
+        if (getVersion() == 0) { // plain name no longer supported from v1
+            ExposedService bean = getConnector().lookup(ExposedService.class.getName());
+            assertThat(bean.createSimpleUser()).isInstanceOf(User.class);
+        }
     }
 
     @Test
     public void ejbByBeanName() throws NamingException {
         // Hybrid bean is not available by name as it implements both remote and local interface
-        RemoteService bean = RemoteConnector.INSTANCE.lookup("java:global/server-app/RemoteServiceBean");
+        RemoteService bean = getConnector().lookup("java:global/server-app/RemoteServiceBean");
         assertThat(bean.createSimpleUser()).isInstanceOf(User.class);
     }
 
     @Test
     public void ejbByBeanAndInterfaceName() throws NamingException {
-        ExposedService bean = RemoteConnector.INSTANCE.lookup("java:global/server-app/HybridBean!"+ExposedService.class.getName());
+        ExposedService bean = getConnector().lookup("java:global/server-app/HybridBean!"+ExposedService.class.getName());
         assertThat(bean.createSimpleUser()).isInstanceOf(User.class);
     }
 }

--- a/samples/ejb-http-remoting/client/src/test/java/RecordTypesIT.java
+++ b/samples/ejb-http-remoting/client/src/test/java/RecordTypesIT.java
@@ -38,28 +38,18 @@
  *    holder.
  */
 
-import fish.payara.samples.ejbhttp.api.RemoteService;
-import fish.payara.samples.ejbhttp.api.User;
-import fish.payara.samples.ejbhttp.client.RemoteConnector;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import javax.naming.NamingException;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
+import org.junit.Test;
+
+import fish.payara.samples.ejbhttp.api.User;
+
 /**
  * Test return values and arguments involving JSON objects mapped to Pojos
  */
-public class RecordTypesIT {
-    static RemoteService remoteService;
-
-    @BeforeClass
-    public static void lookup() throws NamingException {
-        remoteService = RemoteConnector.INSTANCE.lookup("java:global/server-app/RemoteServiceBean");
-    }
+public class RecordTypesIT extends AbstractClientIT {
 
     @Test
     public void testSingleRecord() {
@@ -70,13 +60,17 @@ public class RecordTypesIT {
 
     @Test
     public void testEmptyOptional() {
-        assertFalse("Returned empty optional should serialize as such", remoteService.createOptionalUser(true).isPresent());
+        if (!isJavaSerialization()) { // Optional is not Serializable
+            assertFalse("Returned empty optional should serialize as such", remoteService.createOptionalUser(true).isPresent());
+        }
     }
 
     @Test
     public void testPresentOptional() {
-        User user = remoteService.createOptionalUser(false).get();
-        assertEquals("me", user.login);
-        assertNull(user.friends);
+        if (!isJavaSerialization()) { // Optional is not Serializable
+            User user = remoteService.createOptionalUser(false).get();
+            assertEquals("me", user.login);
+            assertNull(user.friends);
+        }
     }
 }

--- a/samples/ejb-http-remoting/client/src/test/java/SimpleTypesIT.java
+++ b/samples/ejb-http-remoting/client/src/test/java/SimpleTypesIT.java
@@ -38,27 +38,14 @@
  *    holder.
  */
 
-import fish.payara.samples.ejbhttp.api.RemoteService;
-import fish.payara.samples.ejbhttp.client.RemoteConnector;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import javax.naming.NamingException;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
 
 /**
  * Test values and operations involving primitive objects and their collections.
  */
-public class SimpleTypesIT {
-    static RemoteService remoteService;
-
-    @BeforeClass
-    public static void lookup() throws NamingException {
-        remoteService = RemoteConnector.INSTANCE.lookup("java:global/server-app/RemoteServiceBean");
-    }
+public class SimpleTypesIT extends AbstractClientIT {
 
     @Test
     public void testPrimitiveValue() {


### PR DESCRIPTION
This PR parameterises the existing tests so they run for 3 client settings:

* JSONB protocol version 0
* JSONB protocol version 1
* Java Serialisation protocol version 1

To allow Java serialisation the entity types used were made `Serializable`.
In some cases the expected outcome is not consistent. For example can JSONB handle `Optional` types while Java Serialisation cannot since `Optional` is not `Serializable`.
Also JSONB would sometimes use custom serialisers and deserialiser that have an effect on the expected result of method calls.

I added a README that describes how to run the tests.