### PR TITLE
[TEST-345] - Tests Not Applicable to Micro Removed From Micro Testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
         <payara.container.version>1.0.Beta3</payara.container.version>
         <payara.micro.container.version>5.Beta3-m3</payara.micro.container.version>
         <payara_domain>domain1</payara_domain>
+        
+        <micro.isActive>false</micro.isActive>
     </properties>
 
     <repositories>
@@ -307,6 +309,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.21.0</version>
+                
+                <configuration>
+                    <systemPropertyVariables>
+                        <isUsingMicroProfile>${micro.isActive}</isUsingMicroProfile>
+                    </systemPropertyVariables>
+                </configuration>
+                
                 <dependencies>
                     <dependency>
                         <groupId>javax.annotation</groupId>
@@ -515,6 +524,7 @@
                 <skipJMS>true</skipJMS>
                 <skipJAXWS>true</skipJAXWS>
                 <skipClientCertificate>true</skipClientCertificate>
+                <micro.isActive>true</micro.isActive>
             </properties>
 
             <dependencies>

--- a/samples/custom-loginmodule-realm/loginmodule-realm-test/src/test/java/fish/payara/samples/loginmodule/realm/custom/CustomLoginModuleRealmTest.java
+++ b/samples/custom-loginmodule-realm/loginmodule-realm-test/src/test/java/fish/payara/samples/loginmodule/realm/custom/CustomLoginModuleRealmTest.java
@@ -66,9 +66,12 @@ import com.gargoylesoftware.htmlunit.TextPage;
 import com.gargoylesoftware.htmlunit.WebClient;
 
 import fish.payara.samples.CliCommands;
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
 import static fish.payara.samples.ServerOperations.*;
 
-@RunWith(Arquillian.class)
+@NotMicroCompatible
+@RunWith(PayaraArquillianTestRunner.class)
 public class CustomLoginModuleRealmTest {
 
     private static final String WEBAPP_SOURCE = "src/main/webapp";

--- a/samples/custom-loginmodule-realm/loginmodule-realm-test/src/test/java/fish/payara/samples/loginmodule/realm/custom/CustomLoginModuleRealmTest.java
+++ b/samples/custom-loginmodule-realm/loginmodule-realm-test/src/test/java/fish/payara/samples/loginmodule/realm/custom/CustomLoginModuleRealmTest.java
@@ -51,7 +51,6 @@ import java.util.List;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;

--- a/samples/jaxws-tracing-ejb/src/test/java/fish/payara/samples/jaxws/endpoint/ejb/JAXWSEndPointTest.java
+++ b/samples/jaxws-tracing-ejb/src/test/java/fish/payara/samples/jaxws/endpoint/ejb/JAXWSEndPointTest.java
@@ -65,12 +65,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import fish.payara.samples.CliCommands;
+import fish.payara.samples.PayaraArquillianTestRunner;
 import fish.payara.samples.SincePayara;
 
 /**
  * @author Arjan Tijms
  */
-@RunWith(Arquillian.class)
+@RunWith(PayaraArquillianTestRunner.class)
 @FixMethodOrder(NAME_ASCENDING)
 @SincePayara(PAYARA_5_193)
 public class JAXWSEndPointTest {

--- a/samples/jaxws-tracing-ejb/src/test/java/fish/payara/samples/jaxws/endpoint/ejb/JAXWSEndPointTest.java
+++ b/samples/jaxws-tracing-ejb/src/test/java/fish/payara/samples/jaxws/endpoint/ejb/JAXWSEndPointTest.java
@@ -54,7 +54,6 @@ import javax.xml.ws.Service;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;

--- a/samples/oauth2/src/test/java/fish/payara/samples/security/oauth2/test/OAuthTest.java
+++ b/samples/oauth2/src/test/java/fish/payara/samples/security/oauth2/test/OAuthTest.java
@@ -48,7 +48,6 @@ import java.net.URL;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;

--- a/samples/oauth2/src/test/java/fish/payara/samples/security/oauth2/test/OAuthTest.java
+++ b/samples/oauth2/src/test/java/fish/payara/samples/security/oauth2/test/OAuthTest.java
@@ -60,6 +60,8 @@ import org.junit.runner.RunWith;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.TextPage;
 import com.gargoylesoftware.htmlunit.WebClient;
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
 
 import fish.payara.samples.security.oauth2.testapp.Callback;
 import fish.payara.samples.security.oauth2.testapp.Endpoint;
@@ -70,7 +72,8 @@ import fish.payara.samples.security.oauth2.testapp.UnsecuredPage;
  *
  * @author jonathan coustick
  */
-@RunWith(Arquillian.class)
+@NotMicroCompatible
+@RunWith(PayaraArquillianTestRunner.class)
 public class OAuthTest {
     
     private WebClient webClient;

--- a/samples/openid/src/test/java/fish/payara/security/oidc/test/InvalidRedirectURITest.java
+++ b/samples/openid/src/test/java/fish/payara/security/oidc/test/InvalidRedirectURITest.java
@@ -41,6 +41,8 @@ package fish.payara.security.oidc.test;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.WebClient;
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
 import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_REDIRECT_URI;
 import java.io.IOException;
 import java.net.URL;
@@ -62,7 +64,8 @@ import org.junit.runner.RunWith;
  *
  * @author Gaurav Gupta
  */
-@RunWith(Arquillian.class)
+@NotMicroCompatible
+@RunWith(PayaraArquillianTestRunner.class)
 public class InvalidRedirectURITest {
 
     private WebClient webClient;

--- a/samples/openid/src/test/java/fish/payara/security/oidc/test/InvalidRedirectURITest.java
+++ b/samples/openid/src/test/java/fish/payara/security/oidc/test/InvalidRedirectURITest.java
@@ -50,7 +50,6 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;

--- a/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdDefaultTest.java
+++ b/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdDefaultTest.java
@@ -47,7 +47,6 @@ import java.net.URL;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;

--- a/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdDefaultTest.java
+++ b/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdDefaultTest.java
@@ -40,6 +40,8 @@
 package fish.payara.security.oidc.test;
 
 import com.gargoylesoftware.htmlunit.WebClient;
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
 import java.io.IOException;
 import java.net.URL;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -56,7 +58,8 @@ import org.junit.runner.RunWith;
  *
  * @author Gaurav Gupta
  */
-@RunWith(Arquillian.class)
+@NotMicroCompatible
+@RunWith(PayaraArquillianTestRunner.class)
 public class OpenIdDefaultTest {
 
     private WebClient webClient;

--- a/samples/openid/src/test/java/fish/payara/security/oidc/test/UseCookiesTest.java
+++ b/samples/openid/src/test/java/fish/payara/security/oidc/test/UseCookiesTest.java
@@ -49,7 +49,6 @@ import java.net.URL;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;

--- a/samples/openid/src/test/java/fish/payara/security/oidc/test/UseCookiesTest.java
+++ b/samples/openid/src/test/java/fish/payara/security/oidc/test/UseCookiesTest.java
@@ -40,6 +40,8 @@
 package fish.payara.security.oidc.test;
 
 import com.gargoylesoftware.htmlunit.WebClient;
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
 import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_USE_SESSION;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -60,7 +62,8 @@ import fish.payara.samples.ServerOperations;
  *
  * @author Gaurav Gupta
  */
-@RunWith(Arquillian.class)
+@NotMicroCompatible
+@RunWith(PayaraArquillianTestRunner.class)
 public class UseCookiesTest {
 
     private WebClient webClient;

--- a/samples/openid/src/test/java/fish/payara/security/oidc/test/WithoutNonceTest.java
+++ b/samples/openid/src/test/java/fish/payara/security/oidc/test/WithoutNonceTest.java
@@ -40,6 +40,8 @@
 package fish.payara.security.oidc.test;
 
 import com.gargoylesoftware.htmlunit.WebClient;
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
 import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_USE_NONCE;
 import java.io.IOException;
 import java.net.URL;
@@ -58,7 +60,8 @@ import org.junit.runner.RunWith;
  *
  * @author Gaurav Gupta
  */
-@RunWith(Arquillian.class)
+@NotMicroCompatible
+@RunWith(PayaraArquillianTestRunner.class)
 public class WithoutNonceTest {
 
     private WebClient webClient;

--- a/samples/openid/src/test/java/fish/payara/security/oidc/test/WithoutNonceTest.java
+++ b/samples/openid/src/test/java/fish/payara/security/oidc/test/WithoutNonceTest.java
@@ -48,7 +48,6 @@ import java.net.URL;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;

--- a/test-utils/src/main/java/fish/payara/samples/NotMicroCompatible.java
+++ b/test-utils/src/main/java/fish/payara/samples/NotMicroCompatible.java
@@ -1,0 +1,25 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package fish.payara.samples;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used to specify that a test is not applicable to Payara Micro
+ * Use in combination with <code>@RunWith(PayaraTestRunner.class)</code> or <code>@RunWith(PayaraArquillianTestRunner.class)</code> annotation
+ * 
+ * Can also be used in conjunction with <code>@SincePayara</code> to denote versioning
+ * 
+ * @see fish.payara.samples.*
+ * 
+ * @author Cuba Stanley
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NotMicroCompatible {}

--- a/test-utils/src/main/java/fish/payara/samples/PayaraArquillianTestRunner.java
+++ b/test-utils/src/main/java/fish/payara/samples/PayaraArquillianTestRunner.java
@@ -74,7 +74,7 @@ public class PayaraArquillianTestRunner extends Arquillian {
             skipEntireClass = isPayaraSystemPropertyVersionExcludedFromTestPriorTo(sincePayara.value());
         }
         
-        if(klass.getAnnotation(NotMicroCompatible.class) != null) {
+        if (klass.getAnnotation(NotMicroCompatible.class) != null) {
             NotMicroCompatible notMicro = klass.getAnnotation(NotMicroCompatible.class);
             skipEntireClass = isUsingPayaraMicroProfile();
         }
@@ -94,7 +94,7 @@ public class PayaraArquillianTestRunner extends Arquillian {
              if (testMethod.getAnnotation(SincePayara.class) != null 
                     && isPayaraSystemPropertyVersionExcludedFromTestPriorTo(testMethod.getAnnotation(SincePayara.class).value())) {
                 //don't add to test list
-            } else if(testMethod.getAnnotation(NotMicroCompatible.class) != null && isUsingPayaraMicroProfile()) {
+            } else if (testMethod.getAnnotation(NotMicroCompatible.class) != null && isUsingPayaraMicroProfile()) {
                 //don't add to test list
             } else {
                 result.add(testMethod);

--- a/test-utils/src/main/java/fish/payara/samples/PayaraArquillianTestRunner.java
+++ b/test-utils/src/main/java/fish/payara/samples/PayaraArquillianTestRunner.java
@@ -48,6 +48,7 @@ import org.junit.runners.model.InitializationError;
 import org.jboss.arquillian.junit.Arquillian;
 
 import static fish.payara.samples.PayaraVersion.isPayaraSystemPropertyVersionExcludedFromTestPriorTo;
+import static fish.payara.samples.PayaraVersion.isUsingPayaraMicroProfile;
 
 /**
  * An extension of the Arquillian Test Runner. 
@@ -72,6 +73,11 @@ public class PayaraArquillianTestRunner extends Arquillian {
             SincePayara sincePayara = klass.getAnnotation(SincePayara.class);
             skipEntireClass = isPayaraSystemPropertyVersionExcludedFromTestPriorTo(sincePayara.value());
         }
+        
+        if(klass.getAnnotation(NotMicroCompatible.class) != null) {
+            NotMicroCompatible notMicro = klass.getAnnotation(NotMicroCompatible.class);
+            skipEntireClass = isUsingPayaraMicroProfile();
+        }
     }
     
     @Override
@@ -87,6 +93,8 @@ public class PayaraArquillianTestRunner extends Arquillian {
             
              if (testMethod.getAnnotation(SincePayara.class) != null 
                     && isPayaraSystemPropertyVersionExcludedFromTestPriorTo(testMethod.getAnnotation(SincePayara.class).value())) {
+                //don't add to test list
+            } else if(testMethod.getAnnotation(NotMicroCompatible.class) != null && isUsingPayaraMicroProfile()) {
                 //don't add to test list
             } else {
                 result.add(testMethod);

--- a/test-utils/src/main/java/fish/payara/samples/PayaraTestRunner.java
+++ b/test-utils/src/main/java/fish/payara/samples/PayaraTestRunner.java
@@ -48,6 +48,7 @@ import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 
 import static fish.payara.samples.PayaraVersion.isPayaraSystemPropertyVersionExcludedFromTestPriorTo;
+import static fish.payara.samples.PayaraVersion.isUsingPayaraMicroProfile;
 
 /**
  * An extension of the BlockJUnit4ClassRunner. To be used when {@link fish.payara.samples.SincePayara @SincePayara} is used.
@@ -72,6 +73,11 @@ public class PayaraTestRunner extends BlockJUnit4ClassRunner {
             SincePayara sincePayara = klass.getAnnotation(SincePayara.class);
             skipEntireClass = isPayaraSystemPropertyVersionExcludedFromTestPriorTo(sincePayara.value());
         }
+        
+        if(klass.getAnnotation(NotMicroCompatible.class) != null) {
+            NotMicroCompatible notMicro = klass.getAnnotation(NotMicroCompatible.class);
+            skipEntireClass = isUsingPayaraMicroProfile();
+        }
 
     }
     
@@ -88,6 +94,8 @@ public class PayaraTestRunner extends BlockJUnit4ClassRunner {
             
             if (testMethod.getAnnotation(SincePayara.class) != null 
                     && isPayaraSystemPropertyVersionExcludedFromTestPriorTo(testMethod.getAnnotation(SincePayara.class).value())) {
+                //don't add to test list
+            } else if(testMethod.getAnnotation(NotMicroCompatible.class) != null && isUsingPayaraMicroProfile()) {
                 //don't add to test list
             } else {
                 result.add(testMethod);

--- a/test-utils/src/main/java/fish/payara/samples/PayaraTestRunner.java
+++ b/test-utils/src/main/java/fish/payara/samples/PayaraTestRunner.java
@@ -74,7 +74,7 @@ public class PayaraTestRunner extends BlockJUnit4ClassRunner {
             skipEntireClass = isPayaraSystemPropertyVersionExcludedFromTestPriorTo(sincePayara.value());
         }
         
-        if(klass.getAnnotation(NotMicroCompatible.class) != null) {
+        if (klass.getAnnotation(NotMicroCompatible.class) != null) {
             NotMicroCompatible notMicro = klass.getAnnotation(NotMicroCompatible.class);
             skipEntireClass = isUsingPayaraMicroProfile();
         }
@@ -95,7 +95,7 @@ public class PayaraTestRunner extends BlockJUnit4ClassRunner {
             if (testMethod.getAnnotation(SincePayara.class) != null 
                     && isPayaraSystemPropertyVersionExcludedFromTestPriorTo(testMethod.getAnnotation(SincePayara.class).value())) {
                 //don't add to test list
-            } else if(testMethod.getAnnotation(NotMicroCompatible.class) != null && isUsingPayaraMicroProfile()) {
+            } else if (testMethod.getAnnotation(NotMicroCompatible.class) != null && isUsingPayaraMicroProfile()) {
                 //don't add to test list
             } else {
                 result.add(testMethod);

--- a/test-utils/src/main/java/fish/payara/samples/PayaraVersion.java
+++ b/test-utils/src/main/java/fish/payara/samples/PayaraVersion.java
@@ -110,6 +110,19 @@ public enum PayaraVersion {
         return false;
     }
     
+    /**
+     * A method used to determine if we're using the payara-micro profile when running the test suite
+     * Method will be used in conjunction with the <code>@NotMicroCompatible</code> annotation
+     * 
+     * @return whether or not it's running micro profile 
+     */
+    public static boolean isUsingPayaraMicroProfile() {
+        if(System.getProperty("isUsingMicroProfile").equals("true")) {
+            return true;
+        }
+        return false;
+    }
+    
     public boolean isExcludedFromTestPriorTo(PayaraVersion since){
 
         if (since != null) {


### PR DESCRIPTION
Also introduces a new `@NotMicroCompatible` annotation for future use
Additionally updated the JAXWS test to actually use the `@SincePayara` annotation - it works as expected now